### PR TITLE
Add lookahead check for '\0' in xml_parse_string

### DIFF
--- a/xml.h
+++ b/xml.h
@@ -454,7 +454,7 @@ XML_H_API XMLNode *xml_parse_string(const char *xml) {
   XMLNode *root = xml_node_new(NULL, NULL, NULL);
   XMLNode *curr_node = root;
   size_t idx = 0;
-  while (xml[idx] != '\0') {
+  while (xml[idx] != '\0' && xml[idx+1] != '\0') {
     SKIP_WHITESPACE(xml, &idx);
     // Parse tag
     if (xml[idx] == '<') {


### PR DESCRIPTION
Consider the following:
```c
const char xml[] = "<rdf:RDF><rdf:Description> Desc </rdf:Description>\n</rdf:RDF>";
XMLNode* node = xml_parse_string(xml);
xml_node_free(node );
```
This compiles well. Now, if i add a `\n` at the end, or if I use `xml_parse_file()` and my file ends with a `\n` (which is very comon) and i compile with `-fsanitize=address -g`:
```
==489==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6290000045b7 at pc 0x7f141bfd293a bp 0x7fffc9528e10 sp 0x7fffc9528e00
READ of size 1 at 0x6290000045b7 thread T0
    #0 0x7f141bfd2939 in xml_parse_string 3rdparty/xml.h:462
    #1 0x7f141bfd2b1b in xml_parse_file 3rdparty/xml.h:501
    #2 0x7f141bfd3a9a in main {my c file}
    #3 0x7f141b369d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #4 0x7f141b369e3f in __libc_start_main_impl ../csu/libc-start.c:392
    ...
```
```c
XML_H_API XMLNode *xml_parse_string(const char *xml) {
  XMLNode *root = xml_node_new(NULL, NULL, NULL);
  XMLNode *curr_node = root;
  size_t idx = 0;
  while (xml[idx] != '\0') {  // <-- that's line 462
    SKIP_WHITESPACE(xml, &idx);
    // Parse tag
    if (xml[idx] == '<') {
      idx++; // <-- can increment on '\0'
      SKIP_WHITESPACE(xml, &idx);
      if (skip_tags(xml, &idx)) continue;
      if (!parse_tag(xml, &idx, &curr_node)) continue;
    }
    idx++;
  }
  return root;
}
```

Here's the thing: it checks for `\0`, then if it's a whitespace (calls `ispace()` which returns true for `\n`) increment idx, and then access at this index. Out of bound!!

Simplest fix is to do a lookahead for the next character:
```c
while (xml[idx] != '\0' && xml[idx+1] != '\0') { ... }
```