### PR TITLE
fix: handle comments/PIs inside element content in parse_tag

### DIFF
--- a/xml.h
+++ b/xml.h
@@ -415,6 +415,11 @@ static void parse_tag_inner_text(const char *xml, size_t *idx, XMLNode **curr_no
 // Call continue if returns false.
 static bool parse_tag(const char *xml, size_t *idx, XMLNode **curr_node) {
   SKIP_WHITESPACE(xml, idx);
+  // Skip comments and processing instructions inside element content.
+  // xml_parse_string calls skip_tags in its top-level loop, but the
+  // recursive parse_tag path does not — comments inside elements are
+  // mis-parsed as element nodes without this check.
+  if (skip_tags(xml, idx)) return false;
   // End tag </tag>
   if (xml[*idx] == '/') {
     parse_end_tag(xml, idx, curr_node);


### PR DESCRIPTION
xml_parse_string calls skip_tags() in its top-level loop to handle comments (<!-- -->) and processing instructions (<?...?>). However, when parse_tag recurses to handle nested tags inside element content it does not call skip_tags, so comments appearing as children of an element are mis-parsed as element nodes.

Add skip_tags call at the top of parse_tag so the recursive path handles comments and PIs correctly.

Reproducer:
  <root>
    <!-- <child disabled="true"/> -->
    <child active="true"/>
  </root>

Without this fix the commented-out child appears in the parsed tree. With this fix only the active child is present.